### PR TITLE
Add a CPU lowering pass

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,75 @@
+name: Triton-Shared Plugin Testing
+
+on:
+  workflow_call:
+    inputs:
+      triton-ref:
+        required: true
+        type: string
+      triton-shared-ref:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      triton-ref:
+        required: true
+        type: string
+      triton-shared-ref:
+        required: true
+        type: string
+
+jobs:
+  build_and_test_triton_shared:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout Triton
+      uses: actions/checkout@v4
+      with:
+        repository: 'openai/triton'
+        ref: ${{ inputs.triton-ref }}
+        path: triton
+        submodules: 'recursive'
+
+    - name: Checkout Triton-Shared
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.triton-shared-ref }}
+        path: triton/third_party/triton_shared
+
+    - name: Clear Triton Cache
+      run: |
+        rm -rf ~/.triton
+
+    - name: Update PATH
+      run: |
+        echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
+
+    - name: Check pre-commit
+      run: |
+        cd triton
+        python3 -m pip install --upgrade pre-commit
+        python3 -m pre_commit run --all-files --verbose
+
+    - name: Build/Install Triton
+      run: |
+        export TRITON_CODEGEN_TRITON_SHARED=1
+        cd triton/python
+        python3 -m pip install --upgrade pip
+        python3 -m pip install cmake==3.24
+        python3 -m pip install ninja
+        python3 -m pip uninstall -y triton
+        python3 setup.py build
+        python3 -m pip install --no-build-isolation -vvv '.[tests]'
+
+    - name: Install PyTorch
+      run: |
+        python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+    - name: Run an example
+      run: |
+        cd triton/python
+        export TRITON_SHARED_OPT_PATH="$(pwd)/build/$(ls $(pwd)/build | grep -i cmake)/third_party/triton_shared/tools/triton-shared-opt/triton-shared-opt"
+        export LLVM_BINARY_DIR="${HOME}/.triton/llvm/$(ls ${HOME}/.triton/llvm/ | grep -i llvm)/bin"
+        python3 ../third_party/triton_shared/example.py

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,3 +12,9 @@ jobs:
     with:
         triton-ref: '05dc28be0e72dd496300a31b99a21a5a5118f8e9' # known good commit "[CI] refactor workflows (#2504)"
         triton-shared-ref: ${{ github.ref }}
+
+  example:
+    uses: ./.github/workflows/example.yml
+    with:
+        triton-ref: '05dc28be0e72dd496300a31b99a21a5a5118f8e9' # known good commit "[CI] refactor workflows (#2504)"
+        triton-shared-ref: ${{ github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ set(TRITON_SHARED_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include) # Tablegen'd files
 
+set(TRITON_BUILD_PYTHON_MODULE ON)
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(tools)
+add_subdirectory(python)

--- a/example.py
+++ b/example.py
@@ -1,0 +1,34 @@
+
+
+import torch
+
+import triton
+import triton.language as tl
+
+@triton.jit
+def empty_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+  pass
+
+n_elements = 300
+x = torch.rand([n_elements], device="cpu", dtype=torch.float32)
+y = torch.rand([n_elements], device="cpu", dtype=torch.float32)
+grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
+empty_kernel[grid](x, y, n_elements, BLOCK_SIZE=128)
+
+print("Pass!")
+
+@triton.jit
+def meaningless_kernel(
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    val = (n_elements + pid).to(tl.float32)
+    tl.store(output_ptr + pid, val)
+
+ret = triton.compile(meaningless_kernel, signature="*fp32,i32", constants={"BLOCK_SIZE": 128}, device_type="cpu")
+print(ret.asm["ttir"])
+print(ret.asm["ttsharedir"])
+print(ret.asm["llir"])
+print(ret.asm["cpuasm"])

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+# Python module
+if(TRITON_BUILD_PYTHON_MODULE)
+    message(STATUS "Adding Triton-Shared Reference CPU Backend")
+    file(INSTALL
+         ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+         DESTINATION ${PYTHON_THIRD_PARTY_PATH}/cpu/)
+    # TODO: perhaps we want to install binary files used in __init__.py
+endif()

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -11,20 +11,18 @@ from triton.runtime.cache import get_cache_manager
 from triton.runtime.jit import version_key
 
 
-def _get_triton_shared_opt_path():
+def _get_triton_shared_opt_path() -> str:
     path = os.getenv("TRITON_SHARED_OPT_PATH", "")
-    if path is "":
-        assert "TRITON_SHARED_OPT_PATH is not set."
-    else:
-        return path
+    if path == "":
+        assert Exception("TRITON_SHARED_OPT_PATH is not set.")
+    return path
 
 
-def _get_llvm_bin_path(bin_name: str):
+def _get_llvm_bin_path(bin_name: str) -> str:
     path = os.getenv("LLVM_BINARY_DIR", "")
-    if path is "":
-        assert "LLVM_BINARY_DIR is not set."
-    else:
-        return f"{path}/{bin_name}"
+    if path == "":
+        raise Exception("LLVM_BINARY_DIR is not set.")
+    return f"{path}/{bin_name}"
 
 
 def ttir_to_ttsharedir(mod):

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,397 @@
+import functools
+import os
+import sysconfig
+import subprocess
+import tempfile
+from pathlib import Path
+
+from triton.common.backend import BaseBackend, register_backend
+from triton.compiler.make_launcher import make_so_cache_key
+from triton.runtime.cache import get_cache_manager
+from triton.runtime.jit import version_key
+
+
+def _get_triton_shared_opt_path():
+    path = os.getenv("TRITON_SHARED_OPT_PATH", "")
+    if path is "":
+        assert "TRITON_SHARED_OPT_PATH is not set."
+    else:
+        return path
+
+
+def _get_llvm_bin_path(bin_name: str):
+    path = os.getenv("LLVM_BINARY_DIR", "")
+    if path is "":
+        assert "LLVM_BINARY_DIR is not set."
+    else:
+        return f"{path}/{bin_name}"
+
+
+def ttir_to_ttsharedir(mod):
+    # Get Triton-MLIR as string
+    ttir_code = str(mod)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, "tt.mlir")
+        dst_path = os.path.join(tmpdir, "ttshared.mlir")
+        Path(src_path).write_text(ttir_code)
+        triton_shared_opt_path = _get_triton_shared_opt_path()
+        ret = subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg", "-o", dst_path])
+        assert ret == 0
+        return Path(dst_path).read_text()
+
+
+def optimize_ttsharedir(ttsharedir: str):
+    # We don't apply any optimizations now, but we can add passes if needed.
+    return ttsharedir
+
+
+def ttsharedir_to_llir(ttsharedir: str):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, "ttshared.mlir")
+        dst_path = os.path.join(tmpdir, "ll.mlir")
+        dst_path2 = os.path.join(tmpdir, "ll.ir")
+        Path(src_path).write_text(ttsharedir)
+        mlir_opt_path = _get_llvm_bin_path("mlir-opt")
+        # Triton-Shared-MLIR to LLVM-MLIR
+        ret = subprocess.check_call([mlir_opt_path, src_path,
+            "--convert-linalg-to-affine-loops",
+            "--lower-affine",
+            "--convert-scf-to-cf",
+            "--convert-func-to-llvm",
+            "--convert-arith-to-llvm",
+            "--convert-math-to-llvm",
+            "--normalize-memrefs",
+            "--memref-expand",
+            "--fold-memref-alias-ops",
+            "--expand-strided-metadata",
+            "--finalize-memref-to-llvm",
+            "--reconcile-unrealized-casts",
+            "-o",
+            dst_path])
+        assert ret == 0
+
+        # LLVM-MLIR to LLVM-IR
+        mlir_translate_path = _get_llvm_bin_path("mlir-translate")
+        ret = subprocess.check_call([mlir_translate_path, dst_path,
+            "--mlir-to-llvmir",
+            "-o",
+            dst_path2])
+        assert ret == 0
+        return Path(dst_path2).read_text()
+
+
+def optimize_llir(llir: str):
+    # We don't apply any optimizations now, but we can add passes if needed.
+    return llir
+
+
+def llir_to_bin(llir: str):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, "kernel.ll")
+        dst_path = os.path.join(tmpdir, "kernel.o")
+        with open(src_path, "w") as f:
+            f.write(llir)
+        llc_path = _get_llvm_bin_path("llc")
+        ret = subprocess.check_call([llc_path, src_path, "-o", dst_path])
+        assert ret == 0
+        # Actually it's text-format assembly.  Use read_text().
+        return Path(dst_path).read_text()
+
+
+def _ty_to_cpp(ty):
+    if ty[0] == '*':
+        return "void*"
+    return {
+        "i1": "int32_t",
+        "i8": "int8_t",
+        "i16": "int16_t",
+        "i32": "int32_t",
+        "i64": "int64_t",
+        "u32": "uint32_t",
+        "u64": "uint64_t",
+        "fp16": "float",
+        "bf16": "float",
+        "fp32": "float",
+        "f32": "float",
+        "fp64": "double",
+    }[ty]
+
+
+def _generate_launcher(constants, signature, kernel_name):
+    arg_decls = ', '.join(f"{_ty_to_cpp(ty)} arg{i}" for i, ty in signature.items())
+    def _extracted_type(ty):
+        if ty[0] == '*':
+            return "PyObject*"
+        return {
+            'i1': 'int32_t',
+            'i32': 'int32_t',
+            'i64': 'int64_t',
+            'u32': 'uint32_t',
+            'u64': 'uint64_t',
+            'fp16': 'float',
+            'bf16': 'float',
+            'fp32': 'float',
+            'f32': 'float',
+            'fp64': 'double',
+        }[ty]
+
+    def _format_of(ty):
+        return {
+            "PyObject*": "O",
+            "float": "f",
+            "double": "d",
+            "long": "l",
+            "uint32_t": "I",
+            "int32_t": "i",
+            "uint64_t": "K",
+            "int64_t": "L",
+        }[ty]
+
+    format = "iiiOOO" + ''.join([_format_of(_extracted_type(ty)) for ty in signature.values()])
+    arg_decls = ', '.join(f"{_ty_to_cpp(ty)} arg{i}" for i, ty in signature.items())
+    return f"""
+#include <assert.h>
+#include <stdbool.h>
+#include <Python.h>
+
+extern "C" {{
+    void {kernel_name}({', '.join(_ty_to_cpp(ty) for i, ty in signature.items() if i not in constants)},
+                       int, int, int, int, int, int);
+}}
+
+static void _launch(int gridX, int gridY, int gridZ, {arg_decls}) {{
+  if (gridX*gridY*gridZ > 0) {{
+    // Cast "function" to the real function type.
+    for(int x = 0; x < gridX; x++) {{
+      for(int y = 0; y < gridY; y++) {{
+        for(int z = 0; z < gridZ; z++) {{
+          {kernel_name}({', '.join(f"static_cast<{_ty_to_cpp(ty)}>(arg{i})" for i, ty in signature.items() if i not in constants)},
+                        gridX, gridY, gridZ, x, y, z);
+        }}
+      }}
+    }}
+  }}
+}}
+
+typedef struct _DevicePtrInfo {{
+    void *dev_ptr;
+    bool valid;
+}} DevicePtrInfo;
+
+static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
+  DevicePtrInfo ptr_info;
+  ptr_info.dev_ptr = 0;
+  ptr_info.valid = true;
+  if (PyLong_Check(obj)) {{
+    ptr_info.dev_ptr = reinterpret_cast<void *>(PyLong_AsUnsignedLongLong(obj));
+    return ptr_info;
+  }}
+  if (obj == Py_None) {{
+    // valid nullptr
+    return ptr_info;
+  }}
+  PyObject *ptr = PyObject_GetAttrString(obj, "data_ptr");
+  if(ptr){{
+    PyObject *empty_tuple = PyTuple_New(0);
+    PyObject *ret = PyObject_Call(ptr, empty_tuple, NULL);
+    Py_DECREF(empty_tuple);
+    Py_DECREF(ptr);
+    if (!PyLong_Check(ret)) {{
+      PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
+      ptr_info.valid = false;
+      return ptr_info;
+    }}
+    ptr_info.dev_ptr = reinterpret_cast<void *>(PyLong_AsUnsignedLongLong(ret));
+    if(!ptr_info.dev_ptr)
+      return ptr_info;
+    Py_DECREF(ret);  // Thanks ChatGPT!
+    return ptr_info;
+  }}
+  PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
+  return ptr_info;
+}}
+
+static PyObject* launch(PyObject* self, PyObject* args) {{
+  int gridX, gridY, gridZ;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  PyObject *compiled_kernel = NULL;
+  {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
+  if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ, &launch_enter_hook, &launch_exit_hook, &compiled_kernel
+                       {', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''})) {{
+    return NULL;
+  }}
+
+  if (launch_enter_hook != Py_None && !PyObject_CallObject(launch_enter_hook, args)) {{
+    return NULL;
+  }}
+
+  // raise exception asap
+  {"; ".join([f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;" if ty[0] == "*" else "" for i, ty in signature.items()])};
+  _launch(gridX, gridY, gridZ, {', '.join(f"ptr_info{i}.dev_ptr" if ty[0]=="*" else f"_arg{i}"for i, ty in signature.items())});
+
+  if (PyErr_Occurred()) {{
+    return NULL;
+  }}
+  if (launch_exit_hook != Py_None && !PyObject_CallObject(launch_exit_hook, args)) {{
+    return NULL;
+  }}
+
+  // return None
+  Py_INCREF(Py_None);
+  return Py_None;
+}}
+
+static PyMethodDef ModuleMethods[] = {{
+  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
+  {{NULL, NULL, 0, NULL}} // sentinel
+}};
+
+static struct PyModuleDef ModuleDef = {{
+  PyModuleDef_HEAD_INIT,
+  \"__triton_shared_ref_cpu_kernel_launcher\",
+  NULL, //documentation
+  -1, //size
+  ModuleMethods
+}};
+
+PyMODINIT_FUNC PyInit___triton_shared_ref_cpu_kernel_launcher(void) {{
+  PyObject *m = PyModule_Create(&ModuleDef);
+  if(m == NULL) {{
+    return NULL;
+  }}
+  PyModule_AddFunctions(m, ModuleMethods);
+  return m;
+}}
+"""
+
+
+class TritonSharedRefCPUBackend(BaseBackend):
+    stub_so_path = ""
+
+    def __init__(self, device_type: str) -> None:
+        super(TritonSharedRefCPUBackend, self).__init__(device_type)
+
+    def add_stages(self, arch, extern_libs, stages):
+        filter_in_stages = ["ast", "ttir"]
+        filter_out_stages = []
+        for key, _ in stages.items():
+            if key not in filter_in_stages:
+                filter_out_stages.append(key)
+        for filter_out_key in filter_out_stages:
+            stages.pop(filter_out_key)
+
+        stages["ttsharedir"] = (lambda path: Path(path).read_text(),
+                               lambda src: optimize_ttsharedir(ttir_to_ttsharedir(src)))
+        stages["llir"] = (lambda path: Path(path).read_text(),
+                               lambda src: optimize_llir(ttsharedir_to_llir(src)))
+        stages["cpuasm"] = (lambda path: Path(path).read_text(),
+                               lambda src: llir_to_bin(src))
+
+    def add_meta_info(self, ir, module, next_module, metadata, asm):
+        metadata["shared"] = 1
+        if ir == "llir":
+            # We can get a function name (C naming) from
+            # LLVM-IR by getting the first "define void @".
+            metadata["name"] = asm["llir"].split("define void @")[1].split("(")[0].strip()
+
+    def get_driver(self):
+        return None
+
+    def get_stream(self, idx=None) -> int:
+        # Returns int to make Triton happy.
+        return 0
+
+    @functools.lru_cache(None)
+    def get_device_properties(self, device):
+        # CPU has no property.  Return some values to make the Triton runtime happy.
+        return {"max_shared_mem": 2 ** 20}
+
+    def get_current_device(self):
+        # CPU doesn't have a device to return.  Return something.
+        return "cpu"
+
+    def set_current_device(self, device):
+        # CPU doesn't have a device to set
+        assert device == "cpu"
+        return
+
+    def get_load_binary_fn(self):
+        def _load_binary_fn(kernel_name, binary, shared_size, device):
+            # Returns mod, func, n_regs, n_spills, but this implementation does not use it.
+            # Note: func is a function pointer.
+            return None, 0, 0, 0
+        return _load_binary_fn
+
+    def get_kernel_bin(self):
+        return "cpuasm"
+
+    def get_architecture_descriptor(self, **kwargs):
+        # CPU does not have the following parameters, but we need to pass some values to
+        # make the Triton runtime happy.
+        return {"num_warps": 1, "num_stages": 1}
+
+    def make_launcher_stub(self, name, signature, constants, ids):
+        # name of files that are cached
+        so_cache_key = make_so_cache_key(version_key(), signature, constants, ids)
+        so_cache_manager = get_cache_manager(so_cache_key)
+        so_name = f"{name}.py"
+        # retrieve stub from cache if it exists
+        cache_path = so_cache_manager.get_file(so_name)
+        if cache_path is None:
+            kernel_placeholder_name = "KERNEL_NAME_PLACEHOLDER"
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Later KERNEL_NAME_PLACEHOLDER will be used to assign the kernel name
+                # in the following launch function.
+                launcher_src = _generate_launcher(constants, signature, kernel_placeholder_name)
+                # This function was renamed and made public in Python 3.10
+                if hasattr(sysconfig, 'get_default_scheme'):
+                    scheme = sysconfig.get_default_scheme()
+                else:
+                    scheme = sysconfig._get_default_scheme()
+                # 'posix_local' is a custom scheme on Debian. However, starting Python 3.10, the default install
+                # path changes to include 'local'. This change is required to use triton with system-wide python.
+                if scheme == 'posix_local':
+                    scheme = 'posix_prefix'
+                py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
+
+                dst_path = os.path.join(tmpdir, so_name)
+                py_src = f"""
+import os, subprocess, tempfile
+import importlib.util
+from pathlib import Path
+
+def launch(gridX, gridY, gridZ, num_warps, num_ctas, clusterDim0, clusterDim1, clusterDim2,
+           shared, stream, cu_function, launch_enter_hook, launch_exit_hook, compiled_kernel,
+           *args):
+    # Unlike CUDA/HIP, we cannot easily pass function pointer across different pybind libraries.
+    # Let's compile a kernel every time.
+    asm_src = compiled_kernel.asm["{self.get_kernel_bin()}"]
+    launcher_src = '''
+{launcher_src}
+'''.replace("{kernel_placeholder_name}", compiled_kernel.metadata["name"])
+    with tempfile.TemporaryDirectory() as tmpdir:
+        asm_src_path = os.path.join(tmpdir, "kernel.s")
+        launcher_src_path = os.path.join(tmpdir, "main.cxx")
+        so_path = os.path.join(tmpdir, "kernel.so")
+        Path(asm_src_path).write_text(asm_src)
+        Path(launcher_src_path).write_text(launcher_src)
+        # Compile it together.
+        ret = subprocess.check_call(["g++", launcher_src_path, asm_src_path, f"-I{py_include_dir}", "-shared", "-fPIC", "-o", so_path])
+        if ret != 0:
+            raise AssertionError("Kernel compilation failed.")
+
+        # Load and launch the compiled kernel.
+        spec = importlib.util.spec_from_file_location("__triton_shared_ref_cpu_kernel_launcher", so_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.launch(gridX, gridY, gridZ, launch_enter_hook, launch_exit_hook, compiled_kernel, *args)
+"""
+                Path(dst_path).write_text(py_src)
+                with open(dst_path, "rb") as f:
+                    return so_cache_manager.put(f.read(), so_name, binary=True)
+        else:
+            return cache_path
+
+
+register_backend("cpu", TritonSharedRefCPUBackend)


### PR DESCRIPTION
This demonstrates how `triton-shared` can potentially run its lowered linalg + its friends on CPU as a reference.

1. We don't need any changes in the Triton runtime
2. A very basic empty kernel runs, and it succeeds
3. Unfortunately I could not make the standard MLIR lowering passes work for `triton-shared` generated code (it causes SEGV).

Recently Triton updated its test suite to specify the device type iirc, so we can naturally run `test_core.py` using a reference CPU backend if the problem above will be solved. Would it be something interesting?
